### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  packages: write
+  actions: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/core3-coder/context-continue-mcp/security/code-scanning/8](https://github.com/core3-coder/context-continue-mcp/security/code-scanning/8)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `packages: write` for publishing to npm.
- `actions: read` for interacting with GitHub Actions artifacts.
- `pull-requests: write` for managing pull requests (if applicable).
- `issues: write` for adding comments to issues (if applicable).

The `permissions` block should be added at the root level of the workflow to apply to all jobs unless overridden by job-specific permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
